### PR TITLE
Composite Products support

### DIFF
--- a/includes/class-wc-quantity-increment.php
+++ b/includes/class-wc-quantity-increment.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WooCommerce_Quantity_Increment_Init {
 
     function __construct() {
- 
+
     	add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
     }
@@ -22,8 +22,17 @@ class WooCommerce_Quantity_Increment_Init {
     	wp_enqueue_script( 'wcqi-js' );
     	wp_enqueue_style( 'wcqi-css' );
 
+    	add_filter( 'woocommerce_composite_front_end_params', array( $this, 'composite_products_front_end_params' ) );
+
     }
 
+    public function composite_products_front_end_params( $params ) {
+
+    	$params[ 'show_quantity_buttons' ] = 'yes';
+
+    	return $params;
+
+    }
 }
 
 new WooCommerce_Quantity_Increment_Init;


### PR DESCRIPTION
This basically allows quantity markup loaded via ajax to include the plus/minus input elements. This is done entirely on the CP side (part of the js compatibility code for WC 2.2)

No additional code is required.

@bryceadams I know I'm asking for too much -- any chance you can push a v1.0.1 on .org? Had someone freak out about this this other day.