### PR TITLE
made function callable, fixed rounding errors

### DIFF
--- a/assets/js/wc-quantity-increment.js
+++ b/assets/js/wc-quantity-increment.js
@@ -1,45 +1,57 @@
-jQuery( function( $ ) {
+if (!String.prototype.getDecimals) {
+	String.prototype.getDecimals = function() {
+		var num = this,
+			match = ('' + num).match(/(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/);
+		if (!match)
+			return 0;
+		return Math.max(0, (match[1] ? match[1].length : 0) - (match[2] ? +match[2] : 0));
+	}
+}
 
+function wcqi_refresh_quantity_increments(){
 	// Quantity buttons
-	$( 'div.quantity:not(.buttons_added), td.quantity:not(.buttons_added)' ).addClass( 'buttons_added' ).append( '<input type="button" value="+" class="plus" />' ).prepend( '<input type="button" value="-" class="minus" />' );
+	jQuery( 'div.quantity:not(.buttons_added), td.quantity:not(.buttons_added)' ).addClass( 'buttons_added' ).append( '<input type="button" value="+" class="plus" />' ).prepend( '<input type="button" value="-" class="minus" />' );
+}
 
-	$( document ).on( 'click', '.plus, .minus', function() {
+jQuery(document).ready(function(){
+	wcqi_refresh_quantity_increments();
+});
 
-		// Get values
-		var $qty		= $( this ).closest( '.quantity' ).find( '.qty' ),
-			currentVal	= parseFloat( $qty.val() ),
-			max			= parseFloat( $qty.attr( 'max' ) ),
-			min			= parseFloat( $qty.attr( 'min' ) ),
-			step		= $qty.attr( 'step' );
+jQuery( document ).on( 'click', '.plus, .minus', function() {
 
-		// Format values
-		if ( ! currentVal || currentVal === '' || currentVal === 'NaN' ) currentVal = 0;
-		if ( max === '' || max === 'NaN' ) max = '';
-		if ( min === '' || min === 'NaN' ) min = 0;
-		if ( step === 'any' || step === '' || step === undefined || parseFloat( step ) === 'NaN' ) step = 1;
+	// Get values
+	var $qty		= jQuery( this ).closest( '.quantity' ).find( '.qty'),
+		currentVal	= parseFloat( $qty.val() ),
+		max			= parseFloat( $qty.attr( 'max' ) ),
+		min			= parseFloat( $qty.attr( 'min' ) ),
+		step		= $qty.attr( 'step' );
+	
+	// Format values
+	if ( ! currentVal || currentVal === '' || currentVal === 'NaN' ) currentVal = 0;
+	if ( max === '' || max === 'NaN' ) max = '';
+	if ( min === '' || min === 'NaN' ) min = 0;
+	if ( step === 'any' || step === '' || step === undefined || parseFloat( step ) === 'NaN' ) step = 1;
 
-		// Change the value
-		if ( $( this ).is( '.plus' ) ) {
+	// Change the value
+	if ( jQuery( this ).is( '.plus' ) ) {
 
-			if ( max && ( max == currentVal || currentVal > max ) ) {
-				$qty.val( max );
-			} else {
-				$qty.val( currentVal + parseFloat( step ) );
-			}
-
+		if ( max && ( currentVal >= max ) ) {
+			$qty.val( max );
 		} else {
-
-			if ( min && ( min == currentVal || currentVal < min ) ) {
-				$qty.val( min );
-			} else if ( currentVal > 0 ) {
-				$qty.val( currentVal - parseFloat( step ) );
-			}
-
+			$qty.val( (currentVal + parseFloat( step )).toFixed(step.getDecimals()) );
 		}
 
-		// Trigger change event
-		$qty.trigger( 'change' );
+	} else {
 
-	});
+		if ( min && ( currentVal <= min ) ) {
+			$qty.val( min );
+		} else if ( currentVal > 0 ) {
+			$qty.val( (currentVal - parseFloat( step )).toFixed(step.getDecimals()) );
+		}
+
+	}
+
+	// Trigger change event
+	$qty.trigger( 'change' );
 
 });


### PR DESCRIPTION
Some plugins dynamically load new items on the screen and we need a way to call this function in order to refresh the increment buttons. Also there was some problems when using this plugin with others that allow decimal quantities. I've sorted out the rounding errors.